### PR TITLE
Fix spacing around '=' in rich type kwargs.

### DIFF
--- a/adbts/tcp/async.py
+++ b/adbts/tcp/async.py
@@ -51,7 +51,7 @@ class Transport(transport.Transport):
     @exceptions.reraise(OSError)
     @exceptions.reraise_timeout_errors(asyncio.TimeoutError)
     def read(self, num_bytes: hints.Int,
-             timeout: hints.Timeout=timeouts.UNDEFINED) -> transport.TransportReadResult:
+             timeout: hints.Timeout = timeouts.UNDEFINED) -> transport.TransportReadResult:
         """
         Read bytes from the transport.
 
@@ -75,7 +75,7 @@ class Transport(transport.Transport):
     @exceptions.reraise(OSError)
     @exceptions.reraise_timeout_errors(asyncio.TimeoutError)
     def write(self, data: hints.Buffer,
-              timeout: hints.Timeout=timeouts.UNDEFINED) -> transport.TransportWriteResult:
+              timeout: hints.Timeout = timeouts.UNDEFINED) -> transport.TransportWriteResult:
         """
         Write bytes to the transport.
 
@@ -110,8 +110,8 @@ class Transport(transport.Transport):
 @asyncio.coroutine
 @exceptions.reraise(OSError)
 def open(host: hints.Str, port: hints.Int,  # pylint: disable=redefined-builtin
-         timeout: hints.Timeout=timeouts.UNDEFINED,
-         loop: hints.EventLoop=None) -> transport.TransportOpenResult:
+         timeout: hints.Timeout = timeouts.UNDEFINED,
+         loop: hints.EventLoop = None) -> transport.TransportOpenResult:
     """
     Open a new :class:`~adbts.tcp.async.Transport` transport to the given host/port.
 

--- a/adbts/tcp/sync.py
+++ b/adbts/tcp/sync.py
@@ -14,7 +14,7 @@ __all__ = ['Transport']
 
 
 @contextlib.contextmanager
-def socket_timeout_scope(sock: hints.Socket, timeout: hints.Timeout=timeouts.UNDEFINED):
+def socket_timeout_scope(sock: hints.Socket, timeout: hints.Timeout = timeouts.UNDEFINED):
     """
     Patches the socket timeout for the scope of the context manager.
 
@@ -65,7 +65,7 @@ class Transport(transport.Transport):
     @exceptions.reraise(OSError)
     @exceptions.reraise_timeout_errors(socket.timeout)
     def read(self, num_bytes: hints.Int,
-             timeout: hints.Timeout=timeouts.UNDEFINED) -> transport.TransportReadResult:
+             timeout: hints.Timeout = timeouts.UNDEFINED) -> transport.TransportReadResult:
         """
         Read bytes from the transport.
 
@@ -86,7 +86,7 @@ class Transport(transport.Transport):
     @exceptions.reraise(OSError)
     @exceptions.reraise_timeout_errors(socket.timeout)
     def write(self, data: hints.Buffer,
-              timeout: hints.Timeout=timeouts.UNDEFINED) -> transport.TransportWriteResult:
+              timeout: hints.Timeout = timeouts.UNDEFINED) -> transport.TransportWriteResult:
         """
         Write bytes to the transport.
 
@@ -120,7 +120,7 @@ class Transport(transport.Transport):
 @exceptions.reraise(OSError)
 @exceptions.reraise_timeout_errors(socket.timeout)
 def open(host: hints.Str, port: hints.Int,  # pylint: disable=redefined-builtin
-         timeout: hints.Timeout=timeouts.UNDEFINED) -> transport.TransportOpenResult:
+         timeout: hints.Timeout = timeouts.UNDEFINED) -> transport.TransportOpenResult:
     """
     Open a new :class:`~adbts.tcp.sync.Transport` transport to the given host/port.
 

--- a/adbts/transport.py
+++ b/adbts/transport.py
@@ -84,7 +84,7 @@ class Transport(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def read(self, num_bytes: hints.Int, timeout: hints.Timeout=timeouts.UNDEFINED) -> TransportReadResult:
+    def read(self, num_bytes: hints.Int, timeout: hints.Timeout = timeouts.UNDEFINED) -> TransportReadResult:
         """
         Read bytes from the transport.
 
@@ -99,7 +99,7 @@ class Transport(metaclass=abc.ABCMeta):
         """
 
     @abc.abstractmethod
-    def write(self, data: hints.Buffer, timeout: hints.Timeout=timeouts.UNDEFINED) -> TransportWriteResult:
+    def write(self, data: hints.Buffer, timeout: hints.Timeout = timeouts.UNDEFINED) -> TransportWriteResult:
         """
         Write bytes to the transport.
 

--- a/adbts/usb/libusb.py
+++ b/adbts/usb/libusb.py
@@ -210,8 +210,8 @@ def claim_interface(handle, interface_settings):
     handle.claimInterface(interface)
 
 
-def find_device(serial: SerialNumber=None, vid: VendorId=None, pid: ProductId=None,
-                context: OptionalContext=None, skip_on_error: hints.Bool=True) -> Device:
+def find_device(serial: SerialNumber = None, vid: VendorId = None, pid: ProductId = None,
+                context: OptionalContext = None, skip_on_error: hints.Bool = True) -> Device:
     """
     Find a local USB device.
 
@@ -231,8 +231,8 @@ def find_device(serial: SerialNumber=None, vid: VendorId=None, pid: ProductId=No
     return next(find_devices_generator(serial, vid, pid, context, skip_on_error), (None, None))
 
 
-def find_devices_generator(serial: SerialNumber=None, vid: VendorId=None, pid: ProductId=None,
-                           context: OptionalContext=None, skip_on_error: hints.Bool=True) -> DeviceList:
+def find_devices_generator(serial: SerialNumber = None, vid: VendorId = None, pid: ProductId = None,
+                           context: OptionalContext = None, skip_on_error: hints.Bool = True) -> DeviceList:
     """
     Generator function that yields local USB devices.
 
@@ -254,8 +254,8 @@ def find_devices_generator(serial: SerialNumber=None, vid: VendorId=None, pid: P
                 if device_matches(device, settings, serial, vid, pid))
 
 
-def find_devices_interfaces_generator(context: OptionalContext=None,  # pylint: disable=invalid-name
-                                      skip_on_error: hints.Bool=True) -> DeviceList:
+def find_devices_interfaces_generator(context: OptionalContext = None,  # pylint: disable=invalid-name
+                                      skip_on_error: hints.Bool = True) -> DeviceList:
     """
     Generator function that yields combinations of all USB devices with settings
     for all of their interfaces.
@@ -274,7 +274,7 @@ def find_devices_interfaces_generator(context: OptionalContext=None,  # pylint: 
 
 
 def device_matches(device: Device, settings: InterfaceSettings,
-                   serial: SerialNumber=None, vid: VendorId=None, pid: ProductId=None) -> hints.Bool:
+                   serial: SerialNumber = None, vid: VendorId = None, pid: ProductId = None) -> hints.Bool:
     """
     Check if given device and interface settings matches filter.
 
@@ -301,7 +301,7 @@ def device_matches(device: Device, settings: InterfaceSettings,
 
 
 @contextlib.contextmanager
-def optional_usb_context(context: OptionalContext=None) -> typing.Callable:
+def optional_usb_context(context: OptionalContext = None) -> typing.Callable:
     """
     Context manager that uses or creates a USB context for the duration of the block.
 

--- a/adbts/usb/sync.py
+++ b/adbts/usb/sync.py
@@ -53,7 +53,7 @@ class Transport(transport.Transport):
     @transport.ensure_num_bytes
     @libusb.reraise_libusb_errors
     def read(self, num_bytes: hints.Int,
-             timeout: hints.Timeout=timeouts.UNDEFINED) -> transport.TransportReadResult:
+             timeout: hints.Timeout = timeouts.UNDEFINED) -> transport.TransportReadResult:
         """
         Read bytes from the transport.
 
@@ -72,7 +72,7 @@ class Transport(transport.Transport):
     @transport.ensure_data
     @libusb.reraise_libusb_errors
     def write(self, data: hints.Buffer,
-              timeout: hints.Timeout=timeouts.UNDEFINED) -> transport.TransportWriteResult:
+              timeout: hints.Timeout = timeouts.UNDEFINED) -> transport.TransportWriteResult:
         """
         Write bytes to the transport.
 
@@ -107,8 +107,8 @@ class Transport(transport.Transport):
 
 
 @libusb.reraise_libusb_errors
-def open(serial: libusb.SerialNumber=None, vid: libusb.VendorId=None,  # pylint: disable=redefined-builtin
-         pid: libusb.ProductId=None) -> transport.TransportOpenResult:
+def open(serial: libusb.SerialNumber = None, vid: libusb.VendorId = None,  # pylint: disable=redefined-builtin
+         pid: libusb.ProductId = None) -> transport.TransportOpenResult:
     """
     Open a new :class:`~adbts.usb.sync.Transport` transport to a USB device.
 


### PR DESCRIPTION
This was previously reported as a false positive.
See: https://github.com/PyCQA/pylint/issues/1525