### PR TITLE
Freeze coverage.py at '4.3.4' until regression fixed.

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -4,7 +4,7 @@
 
 -r dev.txt
 
-coverage>4.0,<4.4
+coverage>==4.3.4  # pyup: ignore
 
 pytest==3.2.2
 pytest-benchmark==3.1.1


### PR DESCRIPTION
https://bitbucket.org/ned/coveragepy/issues/578/incomplete-file-path-in-xml-report